### PR TITLE
Release process action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Build release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+        # credentials improve quotas
+        #credentials:
+        #  username: ${{ secrets.DH_USER }}
+        #  password: ${{ secrets.DH_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@git-cliff
+
+      - name: Get release notes
+        id: notes
+        run: |
+          notes=$(git cliff -l -s all)
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo $notes >> $GITHUB_OUTPUT
+          echo EOF >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # to have access to the registry service
+          driver-opts: network=host
+
+      - name: Build binaries
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.build
+          platforms: linux/amd64,linux/arm64
+          outputs: type=local,dest=bin
+
+      - name: List and rename binaries
+        run: |
+          ls -Rl bin
+          for arch in `ls -d bin/linux* | cut -f 2 -d _`; do 
+            cp -v bin/linux_${arch}/grafito bin/linux_${arch}/grafito.${arch}
+          done
+
+      - name: Build docker image
+        uses: docker/build-push-action@v6
+        with:
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: localhost:5000/grafito:latest
+          outputs: type=registry,push=true,rewrite-timestamp=true
+
+      - name: Inspect images
+        run: |
+          docker buildx imagetools inspect localhost:5000/grafito:latest --format "{{json .Image}}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload images to ghcr.io
+        run: |
+            date
+            docker -D buildx imagetools create localhost:5000/grafito:latest \
+                                         --tag ghcr.io/${{ github.repository }}:latest \
+                                         --tag ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+      - name: Upload release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          body: ${{ steps.notes.outputs.notes }}
+          fail_on_unmatched_files: true
+          files: |
+            bin/linux_amd64/grafito.amd64
+            bin/linux_arm64/grafito.arm64
+
+      #- name: Publish AUR package
+      #  uses: ulises-jeremias/github-actions-aur-publish@5a3661ae205f5ef93460c0c9fa1117c727b342bf
+      #  with:
+      #    pkgname: my-awesome-package
+      #    pkgbuild: ./PKGBUILD
+      #    commit_username: ${{ secrets.AUR_USERNAME }}
+      #    commit_email: ${{ secrets.AUR_EMAIL }}
+      #    ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+      #    commit_message: Update AUR package
+      #    ssh_keyscan_types: rsa,dsa,ecdsa,ed25519
+      #    update_pkgver: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           ls -Rl bin
           for arch in `ls -d bin/linux* | cut -f 2 -d _`; do 
-            cp -v bin/linux_${arch}/grafito bin/linux_${arch}/grafito.${arch}
+            cp -v bin/linux_${arch}/grafito bin/linux_${arch}/grafito-static-linux-${arch}
           done
 
       - name: Build docker image
@@ -106,8 +106,8 @@ jobs:
           body: ${{ steps.notes.outputs.notes }}
           fail_on_unmatched_files: true
           files: |
-            bin/linux_amd64/grafito.amd64
-            bin/linux_arm64/grafito.arm64
+            bin/linux_amd64/grafito-static-linux-amd64
+            bin/linux_arm64/grafito-static-linux-arm64
 
       #- name: Publish AUR package
       #  uses: ulises-jeremias/github-actions-aur-publish@5a3661ae205f5ef93460c0c9fa1117c727b342bf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM ubuntu:latest
-ARG ARCH=amd64
-ARG VERSION
-LABEL org.opencontainers.image.source="https://github.com/ralsina/grafito"
-LABEL org.opencontainers.image.version="${VERSION}"
-
+ARG TARGETARCH
 RUN apt update && apt -y upgrade && apt -y clean && apt install -y \
     systemd
 
+
 RUN ln -s /usr/share/zoneinfo/UTC /etc/localtime -f
-COPY bin/grafito-static-linux-${ARCH} /usr/local/bin/grafito
+COPY ./bin/linux_${TARGETARCH}/grafito /usr/local/bin/grafito
 CMD ["/usr/local/bin/grafito", "-b", "0.0.0.0"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:edge AS build
+FROM alpine:edge AS build
 RUN apk add --no-cache \
     crystal \
     shards \
@@ -16,3 +16,12 @@ RUN apk add --no-cache \
     zlib-static \
     xz-dev \
     xz-static
+
+COPY . /app
+
+RUN cd /app \
+    && shards build --static --release \
+    && strip bin/grafito
+
+FROM scratch
+COPY --from=build /app/bin/grafito /

--- a/do_release.sh
+++ b/do_release.sh
@@ -5,15 +5,10 @@ PKGNAME=$(basename "$PWD")
 VERSION=$(git cliff --bumped-version --unreleased |cut -dv -f2)
 
 sed "s/^version:.*$/version: $VERSION/g" -i shard.yml
-sed "s/^VERSION=.*$/VERSION=\"$VERSION\" # Hardcoded version/g" -i site/install.sh
-./build_static.sh
 git add shard.yml
-git add site/install.sh
 # hace lint test
 git cliff --bump -o
 git commit -a -m "bump: Release v$VERSION"
 git tag "v$VERSION"
 git push --tags
-gh release create "v$VERSION" "bin/$PKGNAME-static-linux-amd64" "bin/$PKGNAME-static-linux-arm64" --title "Release v$VERSION" --notes "$(git cliff -l -s all)"
-bash -x upload_docker.sh
 bash -x do_aur.sh

--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   baked_file_handler:
     git: https://github.com/ralsina/baked_file_handler.git
-    version: 0.1.0+git.commit.29280afeb2301e2c60ca84812f9c3b47e7505304
+    version: 0.1.5
 
   baked_file_system:
     git: https://github.com/ralsina/baked_file_system.git

--- a/site/install.sh
+++ b/site/install.sh
@@ -7,7 +7,6 @@ INSTALL_DIR="/usr/local/bin"
 SERVICE_DIR="/etc/systemd/system"
 SERVICE_NAME="grafito.service"
 BINARY_NAME="grafito"
-VERSION="0.16.0" # Hardcoded version
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TEMP_DIR}"' EXIT ERR INT TERM # Ensure cleanup
 
@@ -15,7 +14,7 @@ trap 'rm -rf "${TEMP_DIR}"' EXIT ERR INT TERM # Ensure cleanup
 
 # Check if required commands are available
 check_dependencies() {
-    local deps=("curl" "tar" "systemctl") # Removed jq
+    local deps=("curl" "tar" "systemctl" "grep" "tr") # Removed jq
     for dep in "${deps[@]}"; do
         if ! command -v "$dep" &> /dev/null; then
             echo "Error: Required dependency '$dep' is not installed." >&2
@@ -44,6 +43,10 @@ get_architecture() {
     esac
 }
 
+get_version() {
+    curl -s https://api.github.com/repos/ralsina/grafito/releases/latest | grep -o '"v[0-9]*\.[0-9]*\.[0-9]*"' | tr -d '"' 
+}
+
 # --- Main Installation Logic ---
 
 echo "Starting Grafito installation..."
@@ -60,6 +63,12 @@ check_dependencies
 # Get system architecture
 ARCH=$(get_architecture)
 echo "Detected architecture: ${ARCH}"
+
+# If version is not defined - find out the latest one
+if test -z "$VERSION"; then
+    VERSION=$(get_version)
+    echo "The latest version is: ${VERSION}"
+fi
 
 # Construct download URL for the hardcoded version
 echo "Using Grafito version: ${VERSION}"


### PR DESCRIPTION
Hello,

The PR has a workflow which:

- builds binaries
- builds docker images out of binaries
- uploads docker images to ghcr.io
- creates GH release

It can probably also do AUR release, but I've never worked with AUR so not quite sure if I should touch. Though I've found an action which seemingly does what's needed.
The workflow also doesn't touch `site/install.sh` as I don't like changing repository from a workflow. Should probably become a pre-release activity...

The build is /slow/: qemu is slow to compile grafito and I'm too lazy to split the build into a matrix for architectures. But it can be done.

I didn't check that release notes for the GH releases are exactly the same, but I use the same `git cdiff` to generate them. `https://github.com/softprops/action-gh-release` is used for the release creation so maybe use their built-in algorithm for release notes?
I also had to change BakedFileHandler locked version as the previous one was giving me troubles.
Also the workflow changes release file naming slightly (`grafito` for amd64 is now `grafito.amd64`). And the docker image has a single name for all platforms.
And finally, I didn't change all the scripts that use Dockerfiles. The `build_static.sh` is probably broken now.

The workflow is triggered by pushing a tag into the repository.
The idea is to have a release prepared, then tag it and get docker images + GH release in one go.

Let me know your thoughts on this. Given that there are several things I didn't do and you still have to do some thing locally - I'm not quite sure it's that useful. But I'm happy to tweak this further anyways:)